### PR TITLE
add class to instantiate correct class on deserialization of items

### DIFF
--- a/src/Model/IMAGE.php
+++ b/src/Model/IMAGE.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace AllegroApi\Model;
+
+
+class IMAGE extends DescriptionSectionItemImage
+{
+
+}

--- a/src/Model/TEXT.php
+++ b/src/Model/TEXT.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace AllegroApi\Model;
+
+
+class TEXT extends DescriptionSectionItemText
+{
+
+}


### PR DESCRIPTION
Fix #18 

Will force code to instantiance TEXT or IMAGE class with discriminator, thoses classes inherit the right model.

```
//vendor/coffeedesk/allegro-api-client-php/src/ObjectSerializer.php:330
            if (!empty($discriminator) && isset($data->{$discriminator}) && is_string($data->{$discriminator})) {
                $subclass = '\AllegroApi\Model\\' . $data->{$discriminator};
                if (is_subclass_of($subclass, $class)) {
                    $class = $subclass;
                }
            }
```

Regards